### PR TITLE
fix: remove timestamps from payload from post and put requests

### DIFF
--- a/server/cities_endpoints.py
+++ b/server/cities_endpoints.py
@@ -183,7 +183,7 @@ class CitiesList(Resource):
         """
         Create a new city
         Creates a new city with the provided data.
-        Timestamps (created_at, updated_at) are automatically set by the server.
+        Timestamps are automatically set by the server.
         """
         city_data = request.json
 

--- a/server/countries_endpoints.py
+++ b/server/countries_endpoints.py
@@ -80,11 +80,11 @@ country_model = countries_ns.model(
             description="Area in square kilometers", example=9833517.0
         ),
         "created_at": fields.DateTime(
-            description='Creation timestamp (read-only, set by server)', 
+            description='Creation timestamp (read-only, set by server)',
             example='2025-11-12T12:00:00Z'
         ),
         "updated_at": fields.DateTime(
-            description='Last update timestamp (read-only, set by server)', 
+            description='Last update timestamp (read-only, set by server)',
             example='2025-11-12T12:00:00Z'
         ),
     },
@@ -168,7 +168,7 @@ class CountriesList(Resource):
         """
         Create a new country
         Creates a new country with the provided data.
-        Timestamps (created_at, updated_at) are automatically set by the server.
+        Timestamps are automatically set by the server.
         """
         country_data = request.json
 

--- a/server/states_endpoints.py
+++ b/server/states_endpoints.py
@@ -196,7 +196,7 @@ class StatesList(Resource):
         """
         Create a new state
         Creates a new state with the provided data.
-        Timestamps (created_at, updated_at) are automatically set by the server.
+        Timestamps are automatically set by the server.
         """
         state_data = request.json
 


### PR DESCRIPTION
# Remove timestamps from payload from POST and PUT requests

Removed `created_at` and `updated_at` fields from payload of POST and PUT requests from countries, states, and cities endpoints. 
Issue: #8 

## Changes:
`server/countries_endpoints.py`:
- Added a new `country_create_model`
- Updated `country_model`
- Updated POST endpoint

`server/states_endpoints.py`:
- Added a new `state_create_model`
- Updated `state_model`
- Updated POST endpoint

`server/cities_endpoints.py`:
- Added a new `city_create_model`
- Updated `city_model`
- Updated POST endpoint